### PR TITLE
Refactor CI workflow for linting and testing

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-      uses: sersoft-gmbh/xcodebuild-action@v4
+    - uses: sersoft-gmbh/xcodebuild-action@v4
       with:
         spm-package: './'
         scheme: Animations
         destination: platform=iOS
-      uses: sersoft-gmbh/xcodebuild-action@v4
+    - uses: sersoft-gmbh/xcodebuild-action@v4
       with:
         spm-package: './'
         scheme: Animations

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,13 +14,18 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cirruslabs/swiftlint-action@v1
 
-  build-xcode-latest:
+  build-and-test-xcode-latest:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Generate xcodeproj
-      run: swift package generate-xcodeproj
-    - name: Build on iOS
-      run: xcodebuild -scheme Animations-Package -destination "platform=iOS Simulator,OS=13.7,name=iPhone 11 Pro" -sdk iphonesimulator13.7 clean build test
-    - name: Build on tvOS
-      run: xcodebuild -scheme Animations-Package -destination "platform=tvOS Simulator,OS=13.4,name=Apple TV 4K" -sdk appletvsimulator13.4 clean build test
+      uses: sersoft-gmbh/xcodebuild-action@v4
+      with:
+        spm-package: './'
+        scheme: Animations
+        destination: platform=iOS
+      uses: sersoft-gmbh/xcodebuild-action@v4
+      with:
+        spm-package: './'
+        scheme: Animations
+        destination: platform=tvOS
+        action: test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,47 +9,18 @@ on:
 jobs:
 
   lint:
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Lint the code
-      run: swiftlint lint
+    - uses: cirruslabs/swiftlint-action@v1
 
-  build-xc11_7:
-    runs-on: macos-10.15
+  build-xcode-latest:
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Select xcode
-      run: sudo xcode-select -s /Applications/Xcode_11.7.app
     - name: Generate xcodeproj
       run: swift package generate-xcodeproj
     - name: Build on iOS
       run: xcodebuild -scheme Animations-Package -destination "platform=iOS Simulator,OS=13.7,name=iPhone 11 Pro" -sdk iphonesimulator13.7 clean build test
     - name: Build on tvOS
       run: xcodebuild -scheme Animations-Package -destination "platform=tvOS Simulator,OS=13.4,name=Apple TV 4K" -sdk appletvsimulator13.4 clean build test
-
-  build-xc12:
-    runs-on: macos-10.15
-    steps:
-    - uses: actions/checkout@v2
-    - name: Select xcode
-      run: sudo xcode-select -s /Applications/Xcode_12.app
-    - name: Generate xcodeproj
-      run: swift package generate-xcodeproj
-    - name: Build on iOS
-      run: xcodebuild -scheme Animations-Package -destination "platform=iOS Simulator,OS=14.0,name=iPhone 11 Pro" -sdk iphonesimulator14.0 clean build test
-    - name: Build on tvOS
-      run: xcodebuild -scheme Animations-Package -destination "platform=tvOS Simulator,OS=14.0,name=Apple TV 4K" -sdk appletvsimulator14.0 clean build test
-
-  build-xc12_2-beta:
-    runs-on: macos-10.15
-    steps:
-    - uses: actions/checkout@v2
-    - name: Select xcode
-      run: sudo xcode-select -s /Applications/Xcode_12.2.app
-    - name: Generate xcodeproj
-      run: swift package generate-xcodeproj
-    - name: Build on iOS
-      run: xcodebuild -scheme Animations-Package -destination "platform=iOS Simulator,OS=14.2,name=iPhone 12 mini" -sdk iphonesimulator14.2 clean build test
-    - name: Build on tvOS
-      run: xcodebuild -scheme Animations-Package -destination "platform=tvOS Simulator,OS=14.2,name=Apple TV 4K" -sdk appletvsimulator14.2 clean build test

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,19 +18,12 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Get latest simulator
+      run: echo "LATEST_SIM_UDID=$(./script/latest-sim)" >> $GITHUB_OUTPUT
+      id: latest-sim
     - uses: sersoft-gmbh/xcodebuild-action@v4
       with:
         spm-package: './'
         scheme: Animations
-        destination: platform=iOS Simulator
-
-  build-and-test-tvOS-xcode-latest:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: sersoft-gmbh/xcodebuild-action@v4
-      with:
-        spm-package: './'
-        scheme: Animations
-        destination: platform=tvOS
-        action: test
+        destination: id=${{ steps.latest-sim.outputs.LATEST_SIM_UDID }}
+  

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: cirruslabs/swiftlint-action@v1
 
-  build-and-test-xcode-latest:
+  build-and-test-iOS-xcode-latest:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
@@ -22,7 +22,12 @@ jobs:
       with:
         spm-package: './'
         scheme: Animations
-        destination: platform=iOS
+        destination: platform=iOS Simulator
+
+  build-and-test-tvOS-xcode-latest:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
     - uses: sersoft-gmbh/xcodebuild-action@v4
       with:
         spm-package: './'

--- a/script/latest-sim
+++ b/script/latest-sim
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Find and output the UDID of an iOS simulator with the latest version of iOS installed.
+# Works with the plain-text output of `xcrun simctl list devices`.
+
+# Get all iOS runtime versions (lines like: "-- iOS 18.2 --")
+versions=$(
+  xcrun simctl list devices 2>/dev/null \
+  | awk '/^-- iOS[[:space:]]+/ {
+      # remove leading "-- iOS " and trailing " --"
+      line=$0
+      sub(/^-- iOS[[:space:]]*/, "", line)
+      sub(/[[:space:]]*--[[:space:]]*$/, "", line)
+      print line
+    }' \
+  | sort -V -u
+)
+
+if [ -z "$versions" ]; then
+  echo "Error: No iOS runtimes found." >&2
+  exit 1
+fi
+
+# Get the latest version
+latest_version=$(printf "%s\n" "$versions" | tail -n 1)
+
+# Extract the first device UDID for the latest runtime
+udid=$(
+  xcrun simctl list devices 2>/dev/null \
+  | awk -v ver="$latest_version" '
+      BEGIN {in_block=0}
+      # Check if we are entering the target iOS runtime block
+      /^--[[:space:]]+/ {
+        in_block = 0
+        header = $0
+        if (header ~ "^--[[:space:]]*iOS[[:space:]]+" ver) {
+          in_block = 1
+        }
+        next
+      }
+      # If inside the target block, print device lines
+      in_block && /\(/ {
+        print $0
+      }
+    ' \
+  | head -n 1 \
+  | grep -oE '\([0-9A-Fa-f\-]{36}\)|\([0-9A-Fa-f\-]{8,}\)' \
+  | tr -d '()'
+)
+
+if [ -z "$udid" ]; then
+  echo "Error: No simulator found for iOS $latest_version." >&2
+  exit 2
+fi
+
+# Output the UDID
+echo "$udid"


### PR DESCRIPTION
Updated the CI workflow to use Ubuntu for linting and macOS for building. Removed outdated build jobs for Xcode versions 11.7, 12, and 12.2 beta.